### PR TITLE
Monitor node

### DIFF
--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -121,15 +121,12 @@ class Node(TemplateBase):
         self.state.check('status', 'running', 'ok')
         self.state.delete('status', 'running')
 
-        try:
-            # force_reboot = self.data['forceReboot']
-            self._stop_all_containers()
-            self._stop_all_vms()
+        self._stop_all_containers()
+        self._stop_all_vms()
 
-            self.logger.info('reboot node %s' % self.name)
-            self.node_sal.client.raw('core.reboot', {})
-        finally:
-            self.state.set('status', 'rebooting', 'ok')
+        self.logger.info('reboot node %s' % self.name)
+        self.node_sal.client.raw('core.reboot', {})
+        self.state.set('status', 'rebooting', 'ok')
 
     def uninstall(self):
         self.logger.info('uninstalling  node')

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -1,10 +1,5 @@
-import time
 
-from gevent import sleep
-
-import redis
 from js9 import j
-from zerorobot.service_collection import ServiceConflictError
 from zerorobot.template.base import TemplateBase
 from zerorobot.template.decorator import retry, timeout
 from zerorobot.template.state import StateCheckError

--- a/templates/node/node_test.py
+++ b/templates/node/node_test.py
@@ -326,7 +326,7 @@ class TestNodeTemplate(TestCase):
 
         with pytest.raises(StateCheckError,
                            message='template should remove the rebooting status after monitoring'):
-            node.state.check('status', 'running', 'ok')
+            node.state.check('status', 'rebooting', 'ok')
 
     def test_monitor_node(self):
         """


### PR DESCRIPTION
Add a monitor action that makes sure the fscache is mounted again if the node reboots and restarts vms and containers. 

fixes https://github.com/zero-os/0-templates/issues/25