### PR TITLE
don't check for robot that handles node templates anymore

### DIFF
--- a/templates/zeroos_bootstrap/zeroos_bootstrap.py
+++ b/templates/zeroos_bootstrap/zeroos_bootstrap.py
@@ -26,13 +26,6 @@ class ZeroosBootstrap(TemplateBase):
 
     def bootstrap(self):
 
-        # make sure we can find a robot that can create the node service
-        try:
-            self.api.get_robot(NODE_TEMPLATE_UID)
-        except KeyError:
-            self.logger.error("can't find a robot that can create node service. node discovery can't proceed")
-            return
-
         netid = self.data['zerotierNetID']
 
         resp = self.zt.client.network.listMembers(netid)

--- a/templates/zeroos_bootstrap/zeroos_bootstrap_test.py
+++ b/templates/zeroos_bootstrap/zeroos_bootstrap_test.py
@@ -60,17 +60,6 @@ class TestBootstrapTemplate(TestCase):
         bootstrap = ZeroosBootstrap('bootstrap', data=self.valid_data)
         assert bootstrap.data == self.valid_data
 
-    def test_bootstrap_no_robot(self):
-        """
-        Test bootstrap with no zrobot
-        """
-        bootstrap = ZeroosBootstrap('bootstrap', data=self.valid_data)
-        bootstrap.api.get_robot = MagicMock(side_effect=KeyError)
-        bootstrap.logger.error = MagicMock()
-        bootstrap.bootstrap()
-
-        bootstrap.logger.error.assert_called_with("can't find a robot that can create node service. node discovery can't proceed")
-
     def test_bootstrap(self):
         """
         Test creating service with valid data


### PR DESCRIPTION
since this is the local robot that will always be used to install the
node service and both bootstrap and node are part of the same
robot we can assert that node template will always be available.