### PR TITLE
Node primitives

### DIFF
--- a/templates/container/README.md
+++ b/templates/container/README.md
@@ -5,7 +5,6 @@ This template is responsible for creating a container on zero-os nodes
 
 ### Schema:
 
-- `node`: name of the parent node.
 - `hostname`: container hostname.
 - `flist`: url of the root filesystem flist.
 - `initProcesses`: a list of type Processes. These are the processes to be started once the container starts.

--- a/templates/container/schema.capnp
+++ b/templates/container/schema.capnp
@@ -2,22 +2,21 @@
 
 
 struct Schema {
-    node @0 :Text; # pointer to the parent service
-    hostname @1 :Text;
-    flist @2 :Text; # Url to the root filesystem flist
-    initProcesses @3 :List(Process);
-    nics @4 :List(Nic); # Configuration of the attached nics to the container
-    hostNetworking @5 :Bool;
+    hostname @0 :Text;
+    flist @1 :Text; # Url to the root filesystem flist
+    initProcesses @2 :List(Process);
+    nics @3 :List(Nic); # Configuration of the attached nics to the container
+    hostNetworking @4 :Bool;
     # Make host networking available to the guest.
     # If true means that the container will be able participate in the networks available in the host operating system.
-    ports @6:List(Text); # List of node to container port mappings. e.g: 8080:80
-    storage @7 :Text;
-    mounts @8: List(Mount); # List mount points mapping to the container
-    bridges @9 :List(Text); # comsumed bridges, automaticly filled don't pass in blueprint
-    zerotierNetwork @10:Text; # node's zerotier network id
-    privileged @11 :Bool;
-    identity @12 :Text;
-    env @13: List(Env); # environment variables needed to be set for the container
+    ports @5:List(Text); # List of node to container port mappings. e.g: 8080:80
+    storage @6 :Text;
+    mounts @7: List(Mount); # List mount points mapping to the container
+    bridges @8 :List(Text); # comsumed bridges, automaticly filled don't pass in blueprint
+    zerotierNetwork @9:Text; # node's zerotier network id
+    privileged @10 :Bool;
+    identity @11 :Text;
+    env @12: List(Env); # environment variables needed to be set for the container
 
 
     struct Env {

--- a/templates/gateway/gateway.py
+++ b/templates/gateway/gateway.py
@@ -6,6 +6,7 @@ import copy
 CONTAINER_TEMPLATE_UID = 'github.com/zero-os/0-templates/container/0.0.1'
 NODE_TEMPLATE_UID = 'github.com/zero-os/0-templates/node/0.0.1'
 FLIST = 'https://hub.gig.tech/gig-official-apps/zero-os-gw-master.flist'
+NODE_CLIENT = 'local'
 
 
 class Gateway(TemplateBase):
@@ -20,7 +21,7 @@ class Gateway(TemplateBase):
 
     @property
     def node_sal(self):
-        return j.clients.zero_os.sal.get_node(self.data['node'])
+        return j.clients.zero_os.sal.get_node(NODE_CLIENT)
 
     def _get_gateway(self):
         container = self.node_sal.containers.get(self.name)
@@ -38,7 +39,6 @@ class Gateway(TemplateBase):
                         'name': 'z-{}'.format(nic['name']), 'token': zerotierbridge.get('token', '')
                     })
         containerdata = {
-            'node': self.data['node'],
             'flist': FLIST,
             'nics': contnics,
             'hostname': self.data['hostname'],

--- a/templates/gateway/schema.capnp
+++ b/templates/gateway/schema.capnp
@@ -2,17 +2,16 @@
 
 
 struct Schema {
-    node @0 :Text; # pointer to the parent service
-    status @1 :Status;
-    hostname @2 :Text;
-    nics @3 :List(Nic); # Configuration of the attached nics to the container
-    portforwards @4 :List(PortForward);
-    httpproxies @5 :List(HTTPProxy);
-    container @6 :Text; # Container spawned by this service
-    domain @7: Text;
-    advanced @8: Bool; # flag to check if http config has been set manually
-    zerotiernodeid @9:Text;
-    certificates @10 :List(Certificate);
+    status @0 :Status;
+    hostname @1 :Text;
+    nics @2 :List(Nic); # Configuration of the attached nics to the container
+    portforwards @3 :List(PortForward);
+    httpproxies @4 :List(HTTPProxy);
+    container @5 :Text; # Container spawned by this service
+    domain @6: Text;
+    advanced @7: Bool; # flag to check if http config has been set manually
+    zerotiernodeid @8:Text;
+    certificates @9 :List(Certificate);
 
     struct Nic {
         type @0: NicType;

--- a/templates/hardware_check/hardware_check_test.py
+++ b/templates/hardware_check/hardware_check_test.py
@@ -48,7 +48,7 @@ class TestHardwareCheckTemplate(TestCase):
             'chatId': 'supported',
         }
 
-        for key, missing_key in data.items():
+        for key, missing_key in keys.items():
             data[key] = key
             self._test_create_hw_invalid(data, missing_key)
 
@@ -187,7 +187,8 @@ class TestHardwareCheckTemplate(TestCase):
         hw._get_bot_client = MagicMock(return_value=client)
         hw.check('node')
 
-        client.send_message.assert_called_once_with('chatId', 'Node with id node has completed the hardwarecheck successfully.')
+        client.send_message.assert_called_once_with(
+            'chatId', 'Node with id node has completed the hardwarecheck successfully.')
 
     def test_check_fail(self):
         """
@@ -221,5 +222,6 @@ class TestHardwareCheckTemplate(TestCase):
 
         # check with no supported ssd
         hw._disk = MagicMock(return_value=(supported['hddCount'], 0))
-        with pytest.raises(j.exceptions.RuntimeError, message='Template should raise error if ssdCount is not supported'):
+        with pytest.raises(
+                j.exceptions.RuntimeError, message='Template should raise error if ssdCount is not supported'):
             hw.check('node')

--- a/templates/healthcheck/healthcheck.py
+++ b/templates/healthcheck/healthcheck.py
@@ -1,0 +1,83 @@
+from js9 import j
+
+from zerorobot.template.base import TemplateBase
+
+
+NODE_TEMPLATE_UID = 'github.com/zero-os/0-templates/node/0.0.1'
+
+
+class Healthcheck(TemplateBase):
+
+    version = '0.0.1'
+    template_name = "healthcheck"
+
+    def __init__(self, name=None, guid=None, data=None):
+        super().__init__(name=name, guid=guid, data=data)
+        if not self.data['node']:
+            raise ValueError('Invalid node value')
+
+        self.recurring_action('monitor', 30)
+
+    @property
+    def node_sal(self):
+        """
+        connection to the node
+        """
+        return j.clients.zero_os.sal.get_node(self.data['node'])
+
+    def monitor(self):
+        self.logger.info('Monitoring node %s health check' % self.name)
+
+        node = self.api.services.get(name=self.data['node'], template_uid=NODE_TEMPLATE_UID)
+        node.state.check('status', 'running', 'ok')
+
+        self._healthcheck()
+
+    def _healthcheck(self):
+        node_sal = self.node_sal
+        _update_healthcheck_state(self, node_sal.healthcheck.openfiledescriptors())
+        _update_healthcheck_state(self, node_sal.healthcheck.cpu_mem())
+        _update_healthcheck_state(self, node_sal.healthcheck.rotate_logs())
+        _update_healthcheck_state(self, node_sal.healthcheck.network_bond())
+        _update_healthcheck_state(self, node_sal.healthcheck.interrupts())
+        _update_healthcheck_state(self, node_sal.healthcheck.context_switch())
+        _update_healthcheck_state(self, node_sal.healthcheck.threads())
+        _update_healthcheck_state(self, node_sal.healthcheck.qemu_vm_logs())
+        _update_healthcheck_state(self, node_sal.healthcheck.network_load())
+        _update_healthcheck_state(self, node_sal.healthcheck.disk_usage())
+
+        # this is for VM. VM is not implemented yet, and we'll probably not need
+        # some cleanup like this anyhow
+        # node_sal.healthcheck.ssh_cleanup(job=job)
+
+        # TODO: this need to be configurable
+        flist_healhcheck = 'https://hub.gig.tech/gig-official-apps/healthcheck.flist'
+        with node_sal.healthcheck.with_container(flist_healhcheck) as cont:
+            _update_healthcheck_state(self, node_sal.healthcheck.node_temperature(cont))
+            _update_healthcheck_state(self, node_sal.healthcheck.powersupply(cont))
+            _update_healthcheck_state(self, node_sal.healthcheck.fan(cont))
+
+
+def _update(service, healcheck_result):
+    for rprtr in service.data.get('alerta', []):
+        reporter = service.api.services.get(name=rprtr)
+        reporter.schedule_action('process_healthcheck', args={'name': service.name, 'healcheck_result': healcheck_result})
+
+    category = healcheck_result['category'].lower()
+    if len(healcheck_result['messages']) == 1:
+        tag = healcheck_result['id'].lower()
+        status = healcheck_result['messages'][0]['status'].lower()
+        service.state.set(category, tag, status)
+    elif len(healcheck_result['messages']) > 1:
+        for msg in healcheck_result['messages']:
+            tag = ('%s-%s' % (healcheck_result['id'], msg['id'])).lower()
+            status = msg['status'].lower()
+            service.state.set(category, tag, status)
+
+
+def _update_healthcheck_state(service, healthcheck):
+    if isinstance(healthcheck, list):
+        for hc in healthcheck:
+            _update(service, hc)
+    else:
+        _update(service, healthcheck)

--- a/templates/healthcheck/healthcheck.py
+++ b/templates/healthcheck/healthcheck.py
@@ -4,6 +4,7 @@ from zerorobot.template.base import TemplateBase
 
 
 NODE_TEMPLATE_UID = 'github.com/zero-os/0-templates/node/0.0.1'
+NODE_CLIENT = 'local'
 
 
 class Healthcheck(TemplateBase):
@@ -13,8 +14,6 @@ class Healthcheck(TemplateBase):
 
     def __init__(self, name=None, guid=None, data=None):
         super().__init__(name=name, guid=guid, data=data)
-        if not self.data['node']:
-            raise ValueError('Invalid node value')
 
         self.recurring_action('_monitor', 30)
 
@@ -23,14 +22,10 @@ class Healthcheck(TemplateBase):
         """
         connection to the node
         """
-        return j.clients.zero_os.sal.get_node(self.data['node'])
+        return j.clients.zero_os.sal.get_node(NODE_CLIENT)
 
     def _monitor(self):
         self.logger.info('Monitoring node %s health check' % self.name)
-
-        node = self.api.services.get(name=self.data['node'], template_uid=NODE_TEMPLATE_UID)
-        node.state.check('status', 'running', 'ok')
-
         self._healthcheck()
 
     def _healthcheck(self):

--- a/templates/healthcheck/healthcheck.py
+++ b/templates/healthcheck/healthcheck.py
@@ -16,7 +16,7 @@ class Healthcheck(TemplateBase):
         if not self.data['node']:
             raise ValueError('Invalid node value')
 
-        self.recurring_action('monitor', 30)
+        self.recurring_action('_monitor', 30)
 
     @property
     def node_sal(self):
@@ -25,7 +25,7 @@ class Healthcheck(TemplateBase):
         """
         return j.clients.zero_os.sal.get_node(self.data['node'])
 
-    def monitor(self):
+    def _monitor(self):
         self.logger.info('Monitoring node %s health check' % self.name)
 
         node = self.api.services.get(name=self.data['node'], template_uid=NODE_TEMPLATE_UID)

--- a/templates/healthcheck/healthcheck_test.py
+++ b/templates/healthcheck/healthcheck_test.py
@@ -1,0 +1,136 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch, call
+import tempfile
+import shutil
+import os
+import pytest
+
+from zerorobot import config
+from zerorobot.template_uid import TemplateUID
+from zerorobot.template.state import StateCheckError
+
+from healthcheck import Healthcheck, _update_healthcheck_state, _update
+
+
+class TestHealthcheckTemplate(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.valid_data = {'node': 'node'}
+        config.DATA_DIR = tempfile.mkdtemp(prefix='0-templates_')
+        Healthcheck.template_uid = TemplateUID.parse(
+            'github.com/zero-os/0-templates/%s/%s' % (Healthcheck.template_name, Healthcheck.version))
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(config.DATA_DIR):
+            shutil.rmtree(config.DATA_DIR)
+
+    def setUp(self):
+        patch('js9.j.clients', MagicMock()).start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_create_invalid_data(self):
+        """
+        Test Healthcheck creation with invalid data
+        """
+        with pytest.raises(ValueError,
+                           message='template should fail to instantiate if data dict is missing the healthcheck'):
+            Healthcheck(name='healthcheck')
+
+    def test_create_with_valid_data(self):
+        """
+        Test create healthcheck service
+        """
+        healthcheck = Healthcheck(name='healthcheck', data=self.valid_data)
+        assert healthcheck.data == self.valid_data
+
+    def test_node_sal(self):
+        """
+        Test node_sal property
+        """
+        node_sal_return = 'node_sal'
+        get_node = patch('js9.j.clients.zero_os.sal.get_node', MagicMock(return_value=node_sal_return)).start()
+        healthcheck = Healthcheck(name='healthcheck', data=self.valid_data)
+        node_sal = healthcheck.node_sal
+        get_node.assert_called_with(self.valid_data['node'])
+        assert node_sal == node_sal_return
+
+    def test_healthcheck(self):
+        """
+        Test _healthcheck
+        """
+        update_healthcheck = patch('healthcheck._update_healthcheck_state', MagicMock()).start()
+        healthcheck = Healthcheck(name='healthcheck', data=self.valid_data)
+
+        # could be the recurring action already kicked in
+        # so we count the difference in call count
+        pre_exec = update_healthcheck.call_count
+        healthcheck._healthcheck()
+        assert update_healthcheck.call_count == pre_exec + 13
+
+    def test_update_healthcheck_state_list(self):
+        """
+        Test called with list
+        """
+        update = patch('healthcheck._update', MagicMock()).start()
+        healthcheck = MagicMock()
+        _update_healthcheck_state(MagicMock(), [healthcheck, healthcheck])
+        assert update.call_count == 2
+
+    def test_update_healthcheck_state(self):
+        """
+        Test called with one healthcheck
+        """
+        update = patch('healthcheck._update', MagicMock()).start()
+        healthcheck = MagicMock()
+        _update_healthcheck_state(MagicMock(), healthcheck)
+        assert update.call_count == 1
+
+    def test_update_one_message(self):
+        """
+        Test called with one message
+        """
+        healthcheck = {'messages': [{'status': 'status'}], 'category': 'category', 'id': 'id'}
+        service = MagicMock()
+        _update(service, healthcheck)
+        service.state.set.assert_called_once_with('category', 'id', 'status')
+
+    def test_update_multiple_messages(self):
+        """
+        Test called with one message
+        """
+        healthcheck = {
+            'messages': [{'status': 'status', 'id': 1},
+                         {'status': 'status', 'id': 2}],
+            'category': 'category',
+            'id': 'id'
+        }
+        service = MagicMock()
+        _update(service, healthcheck)
+        service.state.set.assert_has_calls([call('category', 'id-1', 'status'), call('category', 'id-2', 'status')])
+
+    def test_monitor_node_is_not_running(self):
+        """
+        Test _monitor action called when node is not running
+        """
+        with pytest.raises(StateCheckError,
+                           message='template should raise a state error if node is not running'):
+            healthcheck = Healthcheck(name='healthcheck', data=self.valid_data)
+            node = MagicMock()
+            node.state.check = MagicMock(side_effect=StateCheckError)
+            healthcheck.api.services.get = MagicMock(return_value=node)
+            healthcheck._monitor()
+
+    def test_monitor_healthcheck(self):
+        """
+        Test _monitor action without reboot
+        """
+        healthcheck = Healthcheck(name='healthcheck', data=self.valid_data)
+        healthcheck.api.services.get = MagicMock()
+        healthcheck._healthcheck = MagicMock()
+        healthcheck._monitor()
+
+        healthcheck._healthcheck.assert_called_with()

--- a/templates/healthcheck/schema.capnp
+++ b/templates/healthcheck/schema.capnp
@@ -1,4 +1,4 @@
-@0xc5ba0f64c9013a79;
+@0xc8120f53ed0b656c; 
 
 struct Schema {
     node @0: Text; # reference to the node service to run the healthcheck on

--- a/templates/healthcheck/schema.capnp
+++ b/templates/healthcheck/schema.capnp
@@ -1,5 +1,5 @@
 @0xc8120f53ed0b656c; 
 
 struct Schema {
-    node @0: Text; # reference to the node service to run the healthcheck on
+    alerta @0 :List(Text);
 }

--- a/templates/healthcheck/schema.capnp
+++ b/templates/healthcheck/schema.capnp
@@ -1,0 +1,5 @@
+@0xc5ba0f64c9013a79;
+
+struct Schema {
+    node @0: Text; # reference to the node service to run the healthcheck on
+}

--- a/templates/minio/minio_test.py
+++ b/templates/minio/minio_test.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 import tempfile
 import shutil
 import os
@@ -31,7 +31,8 @@ class TestMinioTemplate(TestCase):
             'resticUsername': 'username'
         }
         config.DATA_DIR = tempfile.mkdtemp(prefix='0-templates_')
-        Minio.template_uid = TemplateUID.parse('github.com/zero-os/0-templates/%s/%s' % (Minio.template_name, Minio.version))
+        Minio.template_uid = TemplateUID.parse(
+            'github.com/zero-os/0-templates/%s/%s' % (Minio.template_name, Minio.version))
 
     @classmethod
     def tearDownClass(cls):
@@ -82,7 +83,7 @@ class TestMinioTemplate(TestCase):
         get_node.assert_called_once_with(minio.data['node'])
 
     def test_container_sal(self):
-        get_node = patch('js9.j.clients.zero_os.sal.get_node', MagicMock()).start()
+        patch('js9.j.clients.zero_os.sal.get_node', MagicMock()).start()
         minio = Minio('minio', data=self.valid_data)
         minio.node_sal.containers.get = MagicMock(return_value='container')
 
@@ -119,7 +120,8 @@ class TestMinioTemplate(TestCase):
             'ports': ['9000:9000'],
             'nics': [{'type': 'default'}],
         }
-        minio.api.services.find_or_create.assert_called_once_with(CONTAINER_TEMPLATE_UID, self.valid_data['container'], data=container_data)
+        minio.api.services.find_or_create.assert_called_once_with(
+            CONTAINER_TEMPLATE_UID, self.valid_data['container'], data=container_data)
         minio.state.check('actions', 'install', 'ok')
 
     def test_start(self):
@@ -132,7 +134,8 @@ class TestMinioTemplate(TestCase):
         minio._get_zdbs = MagicMock()
         minio.start()
 
-        minio.api.services.get.assert_called_once_with(template_uid=CONTAINER_TEMPLATE_UID, name=self.valid_data['container'])
+        minio.api.services.get.assert_called_once_with(
+            template_uid=CONTAINER_TEMPLATE_UID, name=self.valid_data['container'])
         minio.minio_sal.start.assert_called_once_with()
         minio.state.check('actions', 'start', 'ok')
 

--- a/templates/node/README.md
+++ b/templates/node/README.md
@@ -6,12 +6,7 @@ This template is responsible for managing a zero-os node.
 ### Schema:
 
 - `hostname`: the name of the host. It will be automatically filled when the node is created by the `zero_os_bootstrap` service. **optional**
-- `redisAddr`: the redis address the client uses to connect to the node.
-- `redisPort`: the redis port the client uses to connect to the node. Defaults to 6379.
-- `redisPassword`: the redis password the client uses to connect to the node.
 - `version`: the version of the zero-os. It set by the template.
-- `networks`: network configuration
-- `alerta`: refers to an alerta service which will handle healthcheck reporting
 - `uptime`: node uptime in seconds
 
 
@@ -24,8 +19,6 @@ It waits for 60 seconds for the node to reboot then it starts the containers and
 
 ```yaml
 github.com/zero-os/0-templates/node/0.0.1__525400123456:
-  redisAddr: 172.17.0.1
-  redisPort: 6379
   hostname: "myzeros"
 
 actions:

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -130,7 +130,7 @@ class Node(TemplateBase):
 
         self.logger.info('Rebooting node %s' % self.name)
         self.state.set('status', 'rebooting', 'ok')
-        self.node_sal.client.raw('core.reboot', {})
+        self.node_sal.reboot()
 
     @timeout(30, error_message='info action timeout')
     def info(self):

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -90,8 +90,6 @@ class Node(TemplateBase):
         except StateCheckError:
             pass
 
-        self._healthcheck()
-
     @retry(Exception, tries=2, delay=2)
     def install(self):
         self.logger.info('Installing node %s' % self.name)
@@ -177,32 +175,6 @@ class Node(TemplateBase):
         self.state.check('status', 'running', 'ok')
         return self.node_sal.client.ping()[13:].strip()
 
-    def _healthcheck(self):
-        node_sal = self.node_sal
-        _update_healthcheck_state(self, node_sal.healthcheck.openfiledescriptors())
-        _update_healthcheck_state(self, node_sal.healthcheck.cpu_mem())
-        _update_healthcheck_state(self, node_sal.healthcheck.rotate_logs())
-        _update_healthcheck_state(self, node_sal.healthcheck.network_bond())
-        _update_healthcheck_state(self, node_sal.healthcheck.interrupts())
-        _update_healthcheck_state(self, node_sal.healthcheck.context_switch())
-        _update_healthcheck_state(self, node_sal.healthcheck.threads())
-        _update_healthcheck_state(self, node_sal.healthcheck.qemu_vm_logs())
-        _update_healthcheck_state(self, node_sal.healthcheck.network_load())
-        _update_healthcheck_state(self, node_sal.healthcheck.disk_usage())
-
-        # this is for VM. VM is not implemented yet, and we'll probably not need
-        # some cleanup like this anyhow
-        # node_sal.healthcheck.ssh_cleanup(job=job)
-
-        # TODO: this need to be configurable
-        flist_healhcheck = 'https://hub.gig.tech/gig-official-apps/healthcheck.flist'
-        with node_sal.healthcheck.with_container(flist_healhcheck) as cont:
-            _update_healthcheck_state(self, node_sal.healthcheck.node_temperature(cont))
-            _update_healthcheck_state(self, node_sal.healthcheck.powersupply(cont))
-            _update_healthcheck_state(self, node_sal.healthcheck.fan(cont))
-
-        # TODO: check network stability of  node with the rest of the nodes !
-
     def _start_all_containers(self):
         for container in self.api.services.find(template_uid=CONTAINER_TEMPLATE_UID):
             container.schedule_action('start', args={'node_name': self.name})
@@ -224,28 +196,3 @@ class Node(TemplateBase):
     def _wait_all(self, tasks, timeout=60, die=False):
         for t in tasks:
             t.wait(timeout=timeout, die=die)
-
-
-def _update(service, healcheck_result):
-    for rprtr in service.data.get('alerta', []):
-        reporter = service.api.services.get(name=rprtr)
-        reporter.schedule_action('process_healthcheck', args={'name': service.name, 'healcheck_result': healcheck_result})
-
-    category = healcheck_result['category'].lower()
-    if len(healcheck_result['messages']) == 1:
-        tag = healcheck_result['id'].lower()
-        status = healcheck_result['messages'][0]['status'].lower()
-        service.state.set(category, tag, status)
-    elif len(healcheck_result['messages']) > 1:
-        for msg in healcheck_result['messages']:
-            tag = ('%s-%s' % (healcheck_result['id'], msg['id'])).lower()
-            status = msg['status'].lower()
-            service.state.set(category, tag, status)
-
-
-def _update_healthcheck_state(service, healthcheck):
-    if isinstance(healthcheck, list):
-        for hc in healthcheck:
-            _update(service, hc)
-    else:
-        _update(service, healthcheck)

--- a/templates/node/node_test.py
+++ b/templates/node/node_test.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from node import Node
+from node import Node, NODE_CLIENT
 from zerorobot import config
 from zerorobot.template_uid import TemplateUID
 from zerorobot.template.state import StateCheckError
@@ -27,7 +27,6 @@ class TestNodeTemplate(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.valid_data = {'redisAddr': 'localhost', 'uptime': '30.0'}
         config.DATA_DIR = tempfile.mkdtemp(prefix='0-templates_')
         Node.template_uid = TemplateUID.parse(
             'github.com/zero-os/0-templates/%s/%s' % (Node.template_name, Node.version))
@@ -43,62 +42,21 @@ class TestNodeTemplate(TestCase):
     def tearDown(self):
         patch.stopall()
 
-    def test_create_invalid_data(self):
-        """
-        Test Node creation with invalid data
-        """
-        with pytest.raises(ValueError,
-                           message='template should fail to instantiate if data dict is missing the redisAddr'):
-            Node(name='node')
-
-    def test_create_with_valid_data(self):
-        """
-        Test create node service
-        """
-        node = Node(name='node', data=self.valid_data)
-        data = {
-            'host': node.data['redisAddr'],
-            'port': node.data['redisPort'],
-            'password_': node.data['redisPassword'],
-            'ssl': True,
-            'db': 0,
-            'timeout': 120,
-        }
-        self.client_get.zero_os.get.assert_called_with(instance=node.name, data=data, create=True, die=True)
-
-    def test_update_data(self):
-        """
-        test update_data with new data
-        """
-        node = Node(name='node', data=self.valid_data)
-        node._ensure_client_config = MagicMock()
-        node.update_data({'redisAddr': '127.0.0.1'})
-        node._ensure_client_config.assert_called_once_with()
-
-    def test_update_data_same_data(self):
-        """
-        Test update_data with same data
-        """
-        node = Node(name='node', data=self.valid_data)
-        node._ensure_client_config = MagicMock()
-        node.update_data(node.data)
-        node._ensure_client_config.assert_not_called()
-
     def test_node_sal(self):
         """
         Test node_sal property
         """
         get_node = patch('js9.j.clients.zero_os.sal.get_node', MagicMock(return_value='node_sal')).start()
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         node_sal = node.node_sal
-        get_node.assert_called_with(node.name)
+        get_node.assert_called_with(NODE_CLIENT)
         assert node_sal == 'node_sal'
 
     def test_install(self):
         """
         Test node install
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         node.node_sal.client.info.version = MagicMock(return_value={'branch': 'master', 'revision': 'revision'})
         node.install()
 
@@ -108,66 +66,50 @@ class TestNodeTemplate(TestCase):
         """
         Test node info
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         node.state.set('status', 'running', 'ok')
         node.info()
 
         node.node_sal.client.info.os.assert_called_once_with()
 
-    def test_node_info_node_not_running(self):
-        """
-        Test node info
-        """
-        node = Node(name='node', data=self.valid_data)
-        with pytest.raises(StateCheckError):
-            node.info()
-
     def test_node_stats_node_running(self):
         """
         Test node stats
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         node.state.set('status', 'running', 'ok')
         node.stats()
         node.node_sal.client.aggregator.query.assert_called_once_with()
-
-    def test_node_stats_node_not_running(self):
-        """
-        Test node stats
-        """
-        node = Node(name='node', data=self.valid_data)
-        with pytest.raises(Exception):
-            node.stats()
 
     def test_start_all_containers(self):
         """
         Test node _start_all_containers
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         container = MagicMock()
         node.api.services.find = MagicMock(return_value=[container])
         node._start_all_containers()
 
-        container.schedule_action.assert_called_once_with('start', args={'node_name': 'node'})
+        container.schedule_action.assert_called_once_with('start')
 
     def test_stop_all_containers(self):
         """
         Test node _stop_all_containers
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         container = MagicMock()
         node.api.services.find = MagicMock(return_value=[container])
         node._wait_all = MagicMock()
         node._stop_all_containers()
 
-        container.schedule_action.assert_called_once_with('stop', args={'node_name': 'node'})
+        container.schedule_action.assert_called_once_with('stop')
         assert node._wait_all.called
 
     def test_wait_all(self):
         """
         Test node _wait_all
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         task = MagicMock()
         node._wait_all([task])
 
@@ -176,67 +118,28 @@ class TestNodeTemplate(TestCase):
         node._wait_all([task], timeout=30, die=True)
         task.wait.assert_called_with(timeout=30, die=True)
 
-    def test_uninstall(self):
-        """
-        Test node uninstall
-        """
-        node = Node(name='node', data=self.valid_data)
-        node._stop_all_vms = MagicMock()
-        node._stop_all_containers = MagicMock()
-        bootstrap = MagicMock()
-        node.api.services.find = MagicMock(return_value=[bootstrap])
-        node.uninstall()
-
-        node._stop_all_containers.assert_called_once_with()
-        node._stop_all_vms.assert_called_once_with()
-        bootstrap.schedule_action.assert_called_once_with('delete_node', args={'redis_addr': 'localhost'})
-
-    def test_reboot_node_running(self):
+    def test_reboot_node(self):
         """
         Test node reboot if node already running
         """
-        node = Node(name='node', data=self.valid_data)
-        node.state.set('status', 'running', 'ok')
+        node = Node(name='node')
         node.node_sal.client.raw = MagicMock()
         node.reboot()
 
         node.node_sal.client.raw.assert_called_with('core.reboot', {})
 
-    def test_reboot_node_halted(self):
-        """
-        Test node reboot if node is not
-        """
-        with pytest.raises(StateCheckError, message='template should fail to reboot if node is not running'):
-            node = Node(name='node', data=self.valid_data)
-            node.node_sal.client.raw = MagicMock()
-            node.reboot()
-            assert not node.node_sal.client.raw.called
-
-    def test_monitor_node_is_not_running(self):
-        """
-        Test _monitor action called when node is not running
-        """
-        node = Node(name='node', data=self.valid_data)
-        node.state.set('actions', 'install', 'ok')
-        node.node_sal.is_running = MagicMock(return_value=False)
-        node._monitor()
-
-        with pytest.raises(StateCheckError,
-                           message='template should remove the running status if the node is not running'):
-            node.state.check('status', 'running', 'ok')
-
     def test_monitor_node_reboot(self):
         """
         Test _monitor action called after node rebooted
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node', data={'uptime': 40.0})
         node.install = MagicMock()
         node._start_all_containers = MagicMock()
         node._start_all_vms = MagicMock()
         node.state.set('actions', 'install', 'ok')
         node.state.set('status', 'rebooting', 'ok')
         node.node_sal.is_running = MagicMock(return_value=True)
-        node.node_sal.uptime = MagicMock(return_value='10.0')
+        node.node_sal.uptime = MagicMock(return_value=10.0)
         node._monitor()
 
         node._start_all_containers.assert_called_once_with()
@@ -251,59 +154,25 @@ class TestNodeTemplate(TestCase):
         """
         Test _monitor action without reboot
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         node.install = MagicMock()
         node._start_all_containers = MagicMock()
         node._start_all_vms = MagicMock()
         node.state.set('actions', 'install', 'ok')
         node.node_sal.is_running = MagicMock(return_value=True)
-        node.node_sal.uptime = MagicMock(return_value='40.0')
+        node.node_sal.uptime = MagicMock(return_value=40.0)
         node._monitor()
 
         assert not node._start_all_containers.called
         assert not node._start_all_vms.called
         assert not node.install.called
 
-    def test_monitor_node_previously_running(self):
-        """
-        Test _monitor action called when node was previously running
-        """
-        node = Node(name='node', data=self.valid_data)
-        node.state.set('actions', 'install', 'ok')
-        node.state.set('status', 'running', 'ok')
-        node.node_sal.is_running = MagicMock()
-        node.node_sal.uptime = MagicMock(return_value='30.0')
-        node._monitor()
-
-        node.node_sal.is_running.assert_called_once_with(300)
-
-    def test_monitor_node_previously_not_running(self):
-        """
-        Test _monitor action called when node was previously running
-        """
-        node = Node(name='node', data=self.valid_data)
-        node.state.set('actions', 'install', 'ok')
-        node.node_sal.is_running = MagicMock()
-        node.node_sal.uptime = MagicMock(return_value='30.0')
-        node._monitor()
-
-        node.node_sal.is_running.assert_called_once_with(30)
-
     def test_os_version(self):
         """
         Test os_version action when node is running
         """
-        node = Node(name='node', data=self.valid_data)
+        node = Node(name='node')
         node.state.set('status', 'running', 'ok')
         node.node_sal.client.ping = MagicMock(
             return_value='PONG Version: main @Revision: 41f7eb2e94f6fc9a447f9dec83c67de23537f119')
         node.os_version() == 'main @Revision: 41f7eb2e94f6fc9a447f9dec83c67de23537f119'
-
-    def test_os_version_not_running(self):
-        """
-        Test os_version action when node is not running
-        """
-        node = Node(name='node', data=self.valid_data)
-        with pytest.raises(StateCheckError,
-                           message='os_version action should fail in the node is not running'):
-            node.os_version()

--- a/templates/node/schema.capnp
+++ b/templates/node/schema.capnp
@@ -2,11 +2,6 @@
 
 struct Schema {
     hostname @0: Text;
-    redisAddr @1 :Text; # redis addr for client
-    redisPort @2 :UInt32 = 6379; # redis port for client
-    redisPassword @3 :Text; # redis password for client
-    version @4 :Text;
-    networks @5 :List(Text); # network configuration
-    alerta @6 :List(Text); # reporter service for reporting healthchecks to alerta
-    uptime @7: Float64; # node up time in seconds
+    version @1 :Text;
+    uptime @2: Float64; # node up time in seconds
 }

--- a/templates/vm/README.md
+++ b/templates/vm/README.md
@@ -5,12 +5,10 @@ This template is responsible for managing a vm on a zero-os node.
 
 ### Schema:
 
-- `node`: the node to deploy the vm on.
-- `node`: the node to deploy the vm on.
 - `memory`: amount of memory in MiB. Defaults to 128.
 - `cpu`: number of virtual CPUs. Defaults to 1.
 - `nics`: list of type NicLink specifying the nics of this vm.
-- `vdisks`: list of type DiskLink 
+- `media`: list of Media that can be attached to the vm 
 - `flist`: if specified the vm will boot from this flist and not the vdisk.
 - `vnc`: the vnc port the machine is listening to.
 
@@ -19,16 +17,19 @@ NicLink:
 - `type`: NicType enum specifying the nic type
 - `macaddress`: nic's macaddress
 
-DiskLink:
-- `vdiskId`: vdisk identifier.
-- `maxIOps`: maximum iops for this disk
-
 NicType enum: 
 - `default` 
 - `vlan`
 - `vxlan`
 - `bridge`
 
+Media:
+- `mediaType`: mediaType enum specifying media type
+- `url`: media location
+
+MediaType enum: 
+- `disk` 
+- `cdrom`
 
 ### Actions:
 - `install`: creates a a vm and the hypervisor on the node.

--- a/templates/vm/schema.capnp
+++ b/templates/vm/schema.capnp
@@ -6,12 +6,11 @@ struct Schema {
     memory @0: UInt16 = 128; # Amount of memory in MiB
     cpu @1: UInt16 = 1; # Number of virtual CPUs
     nics @2: List(NicLink);
-    vdisks @3: List(DiskLink);
-    flist @4: Text; # if specified, the vm will boot from an flist and not a vdisk
-    vnc @5: Int32 = -1; # the vnc port the machine is listening to
-    ports @6:List(Text); # List of node to vm port mappings. e.g: 8080:80
-    media @7: List(Media); # list of media to attach to the vm
-    tags @8: List(Text); # list of tags
+    flist @3: Text; # if specified, the vm will boot from an flist and not a vdisk
+    vnc @4: Int32 = -1; # the vnc port the machine is listening to
+    ports @5:List(Text); # List of node to vm port mappings. e.g: 8080:80
+    media @6: List(Media); # list of media to attach to the vm
+    tags @7: List(Text); # list of tags
 
     struct Media {
       type @0: MediaType;
@@ -27,11 +26,6 @@ struct Schema {
       id @0: Text; # VxLan or VLan id
       type @1: NicType;
       macaddress @2: Text;
-    }
-
-    struct DiskLink {
-      vdiskId @0: Text;
-      maxIOps @1: UInt32;
     }
 
     enum NicType {

--- a/templates/vm/schema.capnp
+++ b/templates/vm/schema.capnp
@@ -3,17 +3,15 @@
 
 
 struct Schema {
-    node @0: Text; # pointer to the parent service
-
-    memory @1: UInt16 = 128; # Amount of memory in MiB
-    cpu @2: UInt16 = 1; # Number of virtual CPUs
-    nics @3: List(NicLink);
-    vdisks @4: List(DiskLink);
-    flist @5: Text; # if specified, the vm will boot from an flist and not a vdisk
-    vnc @6: Int32 = -1; # the vnc port the machine is listening to
-    ports @7:List(Text); # List of node to vm port mappings. e.g: 8080:80
-    media @8: List(Media); # list of media to attach to the vm
-    tags @9: List(Text); # list of tags
+    memory @0: UInt16 = 128; # Amount of memory in MiB
+    cpu @1: UInt16 = 1; # Number of virtual CPUs
+    nics @2: List(NicLink);
+    vdisks @3: List(DiskLink);
+    flist @4: Text; # if specified, the vm will boot from an flist and not a vdisk
+    vnc @5: Int32 = -1; # the vnc port the machine is listening to
+    ports @6:List(Text); # List of node to vm port mappings. e.g: 8080:80
+    media @7: List(Media); # list of media to attach to the vm
+    tags @8: List(Text); # list of tags
 
     struct Media {
       type @0: MediaType;

--- a/templates/vm/vm.py
+++ b/templates/vm/vm.py
@@ -3,6 +3,7 @@ from zerorobot.template.base import TemplateBase
 
 NODE_TEMPLATE_UID = "github.com/zero-os/0-templates/node/0.0.1"
 HV_TEMPLATE = 'github.com/zero-os/0-templates/hypervisor/0.0.1'
+NODE_CLIENT = 'local'
 
 
 class Vm(TemplateBase):
@@ -14,27 +15,18 @@ class Vm(TemplateBase):
         super().__init__(name=name, guid=guid, data=data)
 
     def validate(self):
-        if not self.data.get('node'):
-            raise ValueError("invalid input, node can't be None")
-
-        vdisks = self.data.get('vdisks')
-        flist = self.data.get('flist')
-        if not vdisks and not flist:
-            raise ValueError("invalid input. Vm requires a vdisk or flist to be specifed.")
+        if not self.data.get('flist'):
+            raise ValueError("invalid input. Vm requires flist to be specifed.")
 
     @property
     def node_sal(self):
         """
         connection to the zos node
         """
-        return j.clients.zero_os.sal.get_node(self.data['node'])
+        return j.clients.zero_os.sal.get_node(NODE_CLIENT)
 
     def install(self):
         self.logger.info('Installing vm %s' % self.name)
-        node_name = self.data['node']
-        node = self.api.services.get(name=node_name, template_uid=NODE_TEMPLATE_UID)
-        node.state.check('actions', 'install', 'ok')
-        node.state.check('status', 'running', 'ok')
         args = {
             'name': self.name,
             'media': self.data['media'],

--- a/templates/vm/vm.py
+++ b/templates/vm/vm.py
@@ -43,7 +43,6 @@ class Vm(TemplateBase):
 
     def uninstall(self):
         self.logger.info('Uninstalling vm %s' % self.name)
-        # TODO: deal with vdisks
         if self.data.get('uuid'):
             self.node_sal.hypervisor.get(self.data['uuid']).destroy()
 

--- a/templates/vm/vm_test.py
+++ b/templates/vm/vm_test.py
@@ -22,10 +22,10 @@ class TestVmTemplate(TestCase):
             'cpu': 1,
             'flist': 'flist',
             'memory': 128,
-             'nics': [],
-             'node': 'node',
-             'vdisks': [],
-             'vnc': -1,
+            'nics': [],
+            'node': 'node',
+            'vdisks': [],
+            'vnc': -1,
             'ports': [],
             'media': [],
             'mount': {},
@@ -121,7 +121,6 @@ class TestVmTemplate(TestCase):
                            message='install action should raise an error if the hypervisor state is not ok'):
             vm.install()
 
-
     def test_uninstall_vm(self):
         """
         Test successfully destroying the vm
@@ -151,7 +150,6 @@ class TestVmTemplate(TestCase):
         vm.shutdown()
         self.node.hypervisor.get.return_value.shutdown.assert_called_with()
 
-
     def test_pause_vm_hypervisor_not_created(self):
         """
         Test pausing the vm without creation
@@ -170,7 +168,6 @@ class TestVmTemplate(TestCase):
         vm.state = MagicMock()
         vm.pause()
         self.node.hypervisor.get.return_value.pause.assert_called_with()
-
 
     def test_resume_vm_hypervisor_not_created(self):
         """
@@ -191,7 +188,6 @@ class TestVmTemplate(TestCase):
         vm.resume()
         self.node.hypervisor.get.return_value.resume.assert_called_with()
 
-
     def test_reboot_vm_hypervisor_not_created(self):
         """
         Test reboot the vm without creation
@@ -211,7 +207,6 @@ class TestVmTemplate(TestCase):
         vm.reboot()
         self.node.hypervisor.get.return_value.reboot.assert_called_with()
 
-
     def test_reset_vm_hypervisor_not_created(self):
         """
         Test reset the vm without creation
@@ -230,7 +225,6 @@ class TestVmTemplate(TestCase):
         vm.state = MagicMock()
         vm.reset()
         self.node.hypervisor.get.return_value.reset.assert_called_with()
-
 
     def test_enable_vnc(self):
         """

--- a/templates/zerodb/zerodb_test.py
+++ b/templates/zerodb/zerodb_test.py
@@ -28,7 +28,8 @@ class TestZerodbTemplate(TestCase):
             'admin': '',
         }
         config.DATA_DIR = tempfile.mkdtemp(prefix='0-templates_')
-        Zerodb.template_uid = TemplateUID.parse('github.com/zero-os/0-templates/%s/%s' % (Zerodb.template_name, Zerodb.version))
+        Zerodb.template_uid = TemplateUID.parse(
+            'github.com/zero-os/0-templates/%s/%s' % (Zerodb.template_name, Zerodb.version))
 
     @classmethod
     def tearDownClass(cls):
@@ -76,7 +77,6 @@ class TestZerodbTemplate(TestCase):
         get_node.assert_called_once_with(zdb.data['node'])
 
     def test_container_sal(self):
-        get_node = patch('js9.j.clients.zero_os.sal.get_node', MagicMock()).start()
         zdb = Zerodb('zdb', data=self.valid_data)
         zdb.node_sal.containers.get = MagicMock(return_value='container')
 
@@ -109,7 +109,8 @@ class TestZerodbTemplate(TestCase):
             'ports': ['9900:9900'],
             'nics': [{'type': 'default'}],
         }
-        zdb.api.services.find_or_create.assert_called_once_with(CONTAINER_TEMPLATE_UID, self.valid_data['container'], data=container_data)
+        zdb.api.services.find_or_create.assert_called_once_with(
+            CONTAINER_TEMPLATE_UID, self.valid_data['container'], data=container_data)
         zdb.state.check('actions', 'install', 'ok')
 
     def test_start(self):

--- a/templates/zeroos_bootstrap/zeroos_bootstrap_test.py
+++ b/templates/zeroos_bootstrap/zeroos_bootstrap_test.py
@@ -11,6 +11,7 @@ from zeroos_bootstrap import ZeroosBootstrap
 from zerorobot.template.state import StateCheckError
 from zerorobot.service_collection import ServiceNotFoundError
 
+
 def mockdecorator(func):
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -25,9 +26,17 @@ class TestBootstrapTemplate(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.valid_data = {'zerotierClient': 'zt', 'wipeDisks': False, 'zerotierNetID': '', 'redisPassword': '', 'networks': ['storage']}
-        cls.member = {'nodeId': 'id', 'config': {'authorized': False, 'ipAssignments': []}, 'online': False, 'name': 'name'}
-        cls.member2 = {'nodeId': 'id', 'config': {'authorized': False, 'ipAssignments': ['127.0.0.1']}}
+        cls.valid_data = {
+            'zerotierClient': 'zt', 'wipeDisks': False,
+            'zerotierNetID': '', 'redisPassword': '', 'networks': ['storage']
+        }
+        cls.member = {
+            'nodeId': 'id', 'config': {'authorized': False, 'ipAssignments': []},
+            'online': False, 'name': 'name'
+        }
+        cls.member2 = {
+            'nodeId': 'id', 'config': {'authorized': False, 'ipAssignments': ['127.0.0.1']}
+        }
 
         config.DATA_DIR = tempfile.mkdtemp(prefix='0-templates_')
         ZeroosBootstrap.template_uid = TemplateUID.parse(
@@ -54,7 +63,8 @@ class TestBootstrapTemplate(TestCase):
             bootstrap.validate()
 
         # test that the network service doesn't exist
-        with pytest.raises(ServiceNotFoundError, message='Template should raise error if network service doesn\'t exist'):
+        with pytest.raises(
+                ServiceNotFoundError, message='Template should raise error if network service doesn\'t exist'):
             bootstrap = ZeroosBootstrap('bootstrap', data=self.valid_data)
             bootstrap.validate()
 
@@ -89,7 +99,8 @@ class TestBootstrapTemplate(TestCase):
         bootstrap = ZeroosBootstrap('bootstrap', data=self.valid_data)
         bootstrap._authorize_member(self.member)
 
-        bootstrap._zt.client.network.updateMember.called_once_with(self.member, self.member['nodeId'], bootstrap.data['zerotierNetID'])
+        bootstrap._zt.client.network.updateMember.called_once_with(
+            self.member, self.member['nodeId'], bootstrap.data['zerotierNetID'])
 
     def test_unauthorize_member(self):
         """
@@ -98,7 +109,8 @@ class TestBootstrapTemplate(TestCase):
         bootstrap = ZeroosBootstrap('bootstrap', data=self.valid_data)
         bootstrap._unauthorize_member(self.member)
 
-        bootstrap._zt.client.network.updateMember.called_once_with(self.member, self.member['nodeId'], bootstrap.data['zerotierNetID'])
+        bootstrap._zt.client.network.updateMember.called_once_with(
+            self.member, self.member['nodeId'], bootstrap.data['zerotierNetID'])
 
     def test_wait_member_ip(self):
         """
@@ -132,7 +144,7 @@ class TestBootstrapTemplate(TestCase):
             'ssl': True,
             'timeout': 120,
         }
-        node_sal = patch('js9.j.clients.zero_os.sal.get_node', MagicMock(return_value='node')).start()
+        patch('js9.j.clients.zero_os.sal.get_node', MagicMock(return_value='node')).start()
         node = bootstrap._get_node_sal(ip)
 
         zero_os.called_once_with(instance='bootstrap', data=data, create=True, die=True)


### PR DESCRIPTION
- Refactor vm, container, node, gateway and healthcheck templates to run from inside zeroos node.
- Move the healthchecks into a seperate tempalte.