### PR TITLE
GW actions use `name` instead `object_name`

### DIFF
--- a/templates/gateway/gateway.py
+++ b/templates/gateway/gateway.py
@@ -80,16 +80,16 @@ class Gateway(TemplateBase):
             self._gateway_sal.configure_fw()
             raise
 
-    def remove_portforward(self, forward_name):
-        self.logger.info('Remove portforward {}'.format(forward_name))
+    def remove_portforward(self, name):
+        self.logger.info('Remove portforward {}'.format(name))
         self.state.check('actions', 'start', 'ok')
 
         for fw in self.data['portforwards']:
-            if fw['name'] == forward_name:
+            if fw['name'] == name:
                 self.data['portforwards'].remove(fw)
                 break
         else:
-            raise LookupError('Forward {} doesn\'t exist'.format(forward_name))
+            return
 
         try:
             self._gateway_sal.configure_fw()
@@ -119,16 +119,16 @@ class Gateway(TemplateBase):
             self._gateway_sal.configure_http()
             raise
 
-    def remove_http_proxy(self, proxy_name):
-        self.logger.info('Remove http proxy {}'.format(proxy_name))
+    def remove_http_proxy(self, name):
+        self.logger.info('Remove http proxy {}'.format(name))
         self.state.check('actions', 'start', 'ok')
 
         for existing_proxy in self.data['httpproxies']:
-            if existing_proxy['name'] == proxy_name:
+            if existing_proxy['name'] == name:
                 self.data['httpproxies'].remove(existing_proxy)
                 break
         else:
-            raise LookupError('Proxy with name {} doesn\'t exist'.format(proxy_name))
+            return
         try:
             self._gateway_sal.configure_http()
         except:
@@ -225,16 +225,16 @@ class Gateway(TemplateBase):
             self._gateway_sal.deploy()
             raise
 
-    def remove_network(self, network_name):
-        self.logger.info('Remove network {}'.format(network_name))
+    def remove_network(self, name):
+        self.logger.info('Remove network {}'.format(name))
         self.state.check('actions', 'start', 'ok')
 
         for network in self.data['networks']:
-            if network['name'] == network_name:
+            if network['name'] == name:
                 self.data['networks'].remove(network)
                 break
         else:
-            raise LookupError('Network with name {} doesn\'t exists'.format(network_name))
+            return
         try:
             self._gateway_sal.deploy()
         except:

--- a/templates/gateway/gateway_test.py
+++ b/templates/gateway/gateway_test.py
@@ -198,10 +198,9 @@ class TestGatewayTemplate(ZrobotBaseTest):
         """
         Test remove_portforward action if the portforward doesn't exist
         """
-        with pytest.raises(LookupError, message='action should raise an error if portforward doesnt exist'):
-            gw = Gateway('gw', data=self.valid_data)
-            gw.state.set('actions', 'start', 'ok')
-            gw.remove_portforward('pf')
+        gw = Gateway('gw', data=self.valid_data)
+        gw.state.set('actions', 'start', 'ok')
+        gw.remove_portforward('pf')
 
     def test_add_http_proxy(self):
         """
@@ -303,11 +302,9 @@ class TestGatewayTemplate(ZrobotBaseTest):
         """
         Test remove_http_proxy action if proxy doesn't exist
         """
-
-        with pytest.raises(LookupError, message='actions should raise an error if gateway isn\'t started'):
-            gw = Gateway('gw', data=self.valid_data)
-            gw.state.set('actions', 'start', 'ok')
-            gw.remove_http_proxy('proxy')
+        gw = Gateway('gw', data=self.valid_data)
+        gw.state.set('actions', 'start', 'ok')
+        gw.remove_http_proxy('proxy')
 
     def test_add_dhcp_host(self):
         """
@@ -532,11 +529,9 @@ class TestGatewayTemplate(ZrobotBaseTest):
         """
         Test remove_network action if network with name doesnt exist
         """
-        with pytest.raises(LookupError,
-                           message='action should raise an error if network with name doesnt exist'):
-            gw = Gateway('gw', data=self.valid_data)
-            gw.state.set('actions', 'start', 'ok')
-            gw.remove_network('network')
+        gw = Gateway('gw', data=self.valid_data)
+        gw.state.set('actions', 'start', 'ok')
+        gw.remove_network('network')
 
     def test_remove_network_before_start(self):
         """

--- a/templates/public_gateway/public_gateway.py
+++ b/templates/public_gateway/public_gateway.py
@@ -78,12 +78,12 @@ class PublicGateway(TemplateBase):
     def _prefix_name(self, name):
         return '{}_{}'.format(self.guid, name)
 
-    def remove_portforward(self, forward_name):
-        self.logger.info('Remove portforward {}'.format(forward_name))
-        name = self._prefix_name(forward_name)
-        self._gateway_service.schedule_action('remove_portforward', args={'forward_name': name}).wait(die=True)
+    def remove_portforward(self, name):
+        self.logger.info('Remove portforward {}'.format(name))
+        pname = self._prefix_name(name)
+        self._gateway_service.schedule_action('remove_portforward', args={'name': pname}).wait(die=True)
         for forward in self.data['portforwards']:
-            if forward['name'] == forward_name:
+            if forward['name'] == name:
                 self.data['portforwards'].remove(forward)
                 return
 
@@ -94,12 +94,12 @@ class PublicGateway(TemplateBase):
         self._gateway_service.schedule_action('add_http_proxy', args={'proxy': gwproxy}).wait(die=True)
         self.data['httpproxies'].append(proxy)
 
-    def remove_http_proxy(self, proxy_name):
-        self.logger.info('Remove http proxy {}'.format(proxy_name))
-        name = self._prefix_name(proxy_name)
-        self._gateway_service.schedule_action('remove_http_proxy', args={'proxy_name': name}).wait(die=True)
+    def remove_http_proxy(self, name):
+        self.logger.info('Remove http proxy {}'.format(name))
+        pname = self._prefix_name(name)
+        self._gateway_service.schedule_action('remove_http_proxy', args={'name': pname}).wait(die=True)
         for proxy in self.data['httpproxies']:
-            if proxy['name'] == proxy_name:
+            if proxy['name'] == name:
                 self.data['httpproxies'].remove(proxy)
                 return
 
@@ -126,11 +126,11 @@ class PublicGateway(TemplateBase):
         self.logger.info('Uninstall publicservice {}'.format(self.name))
         for portforward in self.data['portforwards']:
             name = self._prefix_name(portforward['name'])
-            gw_service.schedule_action('remove_portforward', args={'forward_name': name}).wait(die=True)
+            gw_service.schedule_action('remove_portforward', args={'name': name}).wait(die=True)
 
         proxies = self.data.get('httpproxies')
         for proxy in proxies:
             name = self._prefix_name(proxy['name'])
-            gw_service.schedule_action('remove_http_proxy', args={'proxy_name': name}).wait(die=True)
+            gw_service.schedule_action('remove_http_proxy', args={'name': name}).wait(die=True)
 
 


### PR DESCRIPTION
Remove actions are omnipotent aka can run multiple times withouth
crashing if something does not exist